### PR TITLE
Add reusable period slider [render preview]

### DIFF
--- a/src/components/CompostStands/CompostStandsTab.tsx
+++ b/src/components/CompostStands/CompostStandsTab.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../store/appSlice';
 import CompostStandChart from './CompostStandChart';
 import { CompostStandTable } from './CompostStandTable';
+import PeriodSlider from '../PeriodSlider';
 
 const initialUserData: CompostStandDataDTO = {
   depositsWeightsByStands: [
@@ -53,13 +54,7 @@ const CompostStandDataDisplay = () => {
   return (
     <div className={'DataDisplay'}>
       <h2 className={'DataDisplay__title'}>Compost Stand Data</h2>
-      <div>PERIOD: {period} days</div>
-      <input
-        defaultValue={30}
-        type={'number'}
-        onChange={(e) => setPeriod(parseInt(e.target.value))}
-        min={0}
-      />
+      <PeriodSlider value={period} onChange={setPeriod} />
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <h1>Compost Stand Table</h1>
         {isStandsListVisible ? (

--- a/src/components/PeriodSlider.tsx
+++ b/src/components/PeriodSlider.tsx
@@ -20,8 +20,7 @@ const PeriodSlider = ({ value, onChange, min = 1, max = 365 }: PeriodSliderProps
   return (
     <div style={{ margin: '10px 0' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.9rem' }}>
-        <span>{formatDate(startDate)}</span>
-        <span>{formatDate(today)} (Today)</span>
+        <span>Date Span: {formatDate(startDate)} -{formatDate(today)} (Today)</span>
       </div>
       <input
         type="range"
@@ -29,7 +28,7 @@ const PeriodSlider = ({ value, onChange, min = 1, max = 365 }: PeriodSliderProps
         max={max}
         value={value}
         onChange={handleChange}
-        style={{ width: '100%' }}
+        style={{ width: '100%', direction: 'rtl' }}
       />
       <div style={{ textAlign: 'center', marginTop: 4 }}>{value} days</div>
     </div>

--- a/src/components/PeriodSlider.tsx
+++ b/src/components/PeriodSlider.tsx
@@ -8,28 +8,55 @@ interface PeriodSliderProps {
   max?: number;
 }
 
-const PeriodSlider = ({ value, onChange, min = 1, max = 365 }: PeriodSliderProps) => {
+const PeriodSlider = ({ value, onChange, min = 1, max = 180 }: PeriodSliderProps) => {
   const today = new Date();
   const startDate = new Date();
   startDate.setDate(today.getDate() - value);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(parseInt(e.target.value));
-  };
+  const handleChange = React.useMemo(() => {
+    let timeout: NodeJS.Timeout;
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = parseInt(e.target.value);
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        onChange(newValue);
+      }, 100);
+    };
+  }, [onChange]);
 
   return (
-    <div style={{ margin: '10px 0' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.9rem' }}>
-        <span>Date Span: {formatDate(startDate)} -{formatDate(today)} (Today)</span>
+    <div style={{ margin: '10px 10px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', fontSize: '0.9rem' }}>
+        <span>Select or enter the number of days from today to display data</span>
+        <span>Date Span: {formatDate(startDate)} - {formatDate(today)} (Today)</span>
       </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        value={value}
-        onChange={handleChange}
-        style={{ width: '100%', direction: 'rtl' }}
-      />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          value={value}
+          onChange={handleChange}
+          style={{
+            width: '100%',
+            direction: 'rtl',
+            height: '32px',
+          }}
+        />
+        <input
+          type="number"
+          min={min}
+          max={max}
+          value={value}
+          onChange={e => {
+            const newValue = parseInt(e.target.value);
+            if (!isNaN(newValue) && newValue >= min && newValue <= max) {
+              onChange(newValue);
+            }
+          }}
+          style={{ width: 60 }}
+        />
+      </div>
       <div style={{ textAlign: 'center', marginTop: 4 }}>{value} days</div>
     </div>
   );

--- a/src/components/PeriodSlider.tsx
+++ b/src/components/PeriodSlider.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { formatDate } from '../utils/timeAndDate';
+
+interface PeriodSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+}
+
+const PeriodSlider = ({ value, onChange, min = 1, max = 365 }: PeriodSliderProps) => {
+  const today = new Date();
+  const startDate = new Date();
+  startDate.setDate(today.getDate() - value);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(parseInt(e.target.value));
+  };
+
+  return (
+    <div style={{ margin: '10px 0' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.9rem' }}>
+        <span>{formatDate(startDate)}</span>
+        <span>{formatDate(today)} (Today)</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={handleChange}
+        style={{ width: '100%' }}
+      />
+      <div style={{ textAlign: 'center', marginTop: 4 }}>{value} days</div>
+    </div>
+  );
+};
+
+export default PeriodSlider;

--- a/src/components/UserDataDisplay.tsx
+++ b/src/components/UserDataDisplay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { fetchUserData } from '../apiServices/userAPI';
 import { UserData } from '../types/UserTypes';
 import { convertUserData } from '../utils/UserDataUtils';
+import PeriodSlider from './PeriodSlider';
 
 
 const UserDataDisplay = () => {
@@ -41,13 +42,7 @@ const UserDataDisplay = () => {
           <b>{userData.userCount}</b>
         </span>
       </div>
-      <div>PERIOD: {period} days</div>
-      <input
-        defaultValue={30}
-        type={'number'}
-        onChange={(e) => setPeriod(parseInt(e.target.value))}
-        min={0}
-      />
+      <PeriodSlider value={period} onChange={setPeriod} />
       <div className={' DataDisplay__property'}>
         <span className='DataDisplay__key'>Number of deposits</span>
         <span className='DataDisplay__value'>


### PR DESCRIPTION
## Summary
- create `PeriodSlider` component for unified period selection
- replace numeric period inputs in `UserDataDisplay` and `CompostStandsTab`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686108bee5e08323947e25ddef355af5